### PR TITLE
Update CircleCI config, don't run "npm install" 2x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,14 @@
 version: 2.1
 orbs:
-  node: circleci/node@2.0.1
+  node: circleci/node@2.1.0
 jobs:
   build-and-test:
     executor:
       name: node/default
-      tag: "12.16"
+      tag: "14.2.0"
     steps:
       - checkout
       - node/install-packages
-      - run: npm install
       - run: npm test
 workflows:
   build-and-test:


### PR DESCRIPTION
These updates don't fix anything in particular, but they should be made at some point and, in my testing on another issue, they appear to be harmless.